### PR TITLE
fix(Makefile): LDFLAGS should come last

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CFLAGS = `pkg-config sdl2 --cflags` -D_GNU_SOURCE -Wall -Wextra -Wno-unused-para
 LDFLAGS = `pkg-config sdl2 --libs` -lm
 
 $(TARGET): $(OBJS)
-	$(CC) $(LDFLAGS) -o $(TARGET) $(OBJS)
+	$(CC) -o $(TARGET) $(OBJS) $(LDFLAGS)
 
 all: $(TARGET)
 


### PR DESCRIPTION
For the reason why this is needed:
https://stackoverflow.com/questions/9417169/why-does-the-library-linker-flag-sometimes-have-to-go-at-the-end-using-gcc

On your system, this may be resolving. However, on other systems like
Ubuntu, we absolutely need linking to be the last step in a compilation
process (after code objects are known).

Signed-off-by: Kevin Morris <kevr@0cost.org>